### PR TITLE
Add persistent game history and expose via server

### DIFF
--- a/src/main/java/com/reversi/client/LobbyView.java
+++ b/src/main/java/com/reversi/client/LobbyView.java
@@ -16,6 +16,7 @@ public class LobbyView {
   private Button joinButton;
   private Button createButton;
   private Button botButton;
+  private Button historyButton;
   private Label lobbyStatusLabel;
   private ListView<String> roomsListView;
 
@@ -47,6 +48,8 @@ public class LobbyView {
 
     joinButton = new Button("Join Room");
     createButton = new Button("Create Room");
+
+    historyButton = new Button("History");
 
     // List view for available rooms.
     roomsListView = new ListView<>();
@@ -83,6 +86,11 @@ public class LobbyView {
     topBox.setAlignment(Pos.CENTER);
     topBox.setPadding(new Insets(10));
     mainPane.setTop(topBox);
+
+    HBox bottomBox = new HBox(historyButton);
+    bottomBox.setAlignment(Pos.CENTER);
+    bottomBox.setPadding(new Insets(10));
+    mainPane.setBottom(bottomBox);
   }
 
   private void attachListeners() {
@@ -104,6 +112,10 @@ public class LobbyView {
       } else {
         lobbyStatusLabel.setText("Room ID cannot be empty.");
       }
+    });
+
+    historyButton.setOnAction(e -> {
+      serverSocket.send(new Message(new Message.HistoryRequest()));
     });
 
     // Enable joining via double click on a room in the list.

--- a/src/main/java/com/reversi/client/ReversiApp.java
+++ b/src/main/java/com/reversi/client/ReversiApp.java
@@ -4,6 +4,10 @@ import com.reversi.common.EventBus;
 import com.reversi.common.EventListener;
 import com.reversi.common.Message;
 import com.reversi.common.Player;
+import com.reversi.common.GameRecord;
+import java.util.List;
+import java.util.Date;
+import javafx.scene.control.Alert;
 import javafx.application.Application;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
@@ -93,6 +97,17 @@ public class ReversiApp extends Application {
       case GameOver:
         Message.GameOver over = (Message.GameOver)msg.getMessage();
         gameView.showGameOver(over.getReason());
+        break;
+      case HistoryData:
+        Message.HistoryData hd = (Message.HistoryData)msg.getMessage();
+        List<GameRecord> records = hd.getRecords();
+        StringBuilder sb = new StringBuilder();
+        for (GameRecord r : records) {
+          sb.append(String.format("%1$tF %1$tT - B:%d W:%d Winner:%c%n", new Date(r.getTimestamp()), r.getBlackScore(), r.getWhiteScore(), r.getWinner()));
+        }
+        Alert alert = new Alert(Alert.AlertType.INFORMATION, sb.toString());
+        alert.setHeaderText("Game History");
+        alert.showAndWait();
         break;
       case Invalid:
         // TODO: no-op for now

--- a/src/main/java/com/reversi/common/GameRecord.java
+++ b/src/main/java/com/reversi/common/GameRecord.java
@@ -1,0 +1,29 @@
+package com.reversi.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** Represents a completed game result. */
+public class GameRecord {
+  private final char winner;
+  private final int blackScore;
+  private final int whiteScore;
+  private final long timestamp;
+
+  @JsonCreator
+  public GameRecord(
+      @JsonProperty("winner") char winner,
+      @JsonProperty("blackScore") int blackScore,
+      @JsonProperty("whiteScore") int whiteScore,
+      @JsonProperty("timestamp") long timestamp) {
+    this.winner = winner;
+    this.blackScore = blackScore;
+    this.whiteScore = whiteScore;
+    this.timestamp = timestamp;
+  }
+
+  public char getWinner() { return winner; }
+  public int getBlackScore() { return blackScore; }
+  public int getWhiteScore() { return whiteScore; }
+  public long getTimestamp() { return timestamp; }
+}

--- a/src/main/java/com/reversi/common/Message.java
+++ b/src/main/java/com/reversi/common/Message.java
@@ -12,8 +12,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
 import java.io.IOException;
 import java.util.Map;
+import com.reversi.common.GameRecord;
 
 @JsonSerialize(using = Message.Serializer.class)
 @JsonDeserialize(using = Message.Deserializer.class)
@@ -111,6 +113,19 @@ public class Message {
     public Map<String, LobbyRoom> getLobbyRooms() { return lobbyRooms; }
   }
 
+  public static class HistoryRequest {}
+
+  public static class HistoryData {
+    private final java.util.List<GameRecord> records;
+
+    @JsonCreator
+    public HistoryData(@JsonProperty("records") java.util.List<GameRecord> records) {
+      this.records = records;
+    }
+
+    public java.util.List<GameRecord> getRecords() { return records; }
+  }
+
   // Tagged union storage
   private final Object msg;
   private final Type type;
@@ -125,7 +140,9 @@ public class Message {
     LobbyReady,
     GameUpdate,
     LobbyCreate,
-    LobbyUpdate
+    LobbyUpdate,
+    HistoryRequest,
+    HistoryData
   }
 
   // Constructors for different message types.
@@ -164,6 +181,14 @@ public class Message {
   public Message(GameOver msg) {
     this.msg = msg;
     this.type = Type.GameOver;
+  }
+  public Message(HistoryRequest msg) {
+    this.msg = msg;
+    this.type = Type.HistoryRequest;
+  }
+  public Message(HistoryData msg) {
+    this.msg = msg;
+    this.type = Type.HistoryData;
   }
 
   // No-arg constructor for Jackson
@@ -246,6 +271,14 @@ public class Message {
         LobbyUpdate lobbyUpdate =
             mapper.treeToValue(msgNode, LobbyUpdate.class);
         return new Message(lobbyUpdate);
+
+      case HistoryRequest:
+        HistoryRequest historyReq = mapper.treeToValue(msgNode, HistoryRequest.class);
+        return new Message(historyReq);
+
+      case HistoryData:
+        HistoryData historyData = mapper.treeToValue(msgNode, HistoryData.class);
+        return new Message(historyData);
 
       default:
         throw new IllegalStateException("Unexpected type: " + typeStr);

--- a/src/main/java/com/reversi/server/HistoryStore.java
+++ b/src/main/java/com/reversi/server/HistoryStore.java
@@ -1,0 +1,52 @@
+package com.reversi.server;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.reversi.common.GameRecord;
+import com.reversi.common.JacksonObjMapper;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Simple file-based storage for completed game records. */
+public class HistoryStore {
+  private static final Logger logger = LoggerFactory.getLogger(HistoryStore.class);
+  private static final String FILE_NAME = "game_history.json";
+
+  private final List<GameRecord> history = new ArrayList<>();
+
+  public HistoryStore() { load(); }
+
+  private void load() {
+    File f = new File(FILE_NAME);
+    if (!f.exists()) return;
+    try {
+      List<GameRecord> data =
+          JacksonObjMapper.get()
+              .readValue(f, new TypeReference<List<GameRecord>>() {});
+      history.addAll(data);
+    } catch (IOException e) {
+      logger.error("Failed to load history", e);
+    }
+  }
+
+  private void save() {
+    File f = new File(FILE_NAME);
+    try {
+      JacksonObjMapper.get().writerWithDefaultPrettyPrinter().writeValue(f, history);
+    } catch (IOException e) {
+      logger.error("Failed to save history", e);
+    }
+  }
+
+  public synchronized void addRecord(GameRecord rec) {
+    history.add(rec);
+    save();
+  }
+
+  public synchronized List<GameRecord> getHistory() {
+    return new ArrayList<>(history);
+  }
+}

--- a/src/main/java/com/reversi/server/ServerMain.java
+++ b/src/main/java/com/reversi/server/ServerMain.java
@@ -6,6 +6,7 @@ import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import com.reversi.server.HistoryStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,9 +20,9 @@ public class ServerMain {
   // ExecutorService for managing client tasks
   private final ExecutorService clientThreadPool =
       Executors.newCachedThreadPool();
-  // SessionHub takes care of all server-client messaging and game
-  // state updates.
-  private final SessionHub session = new SessionHub();
+  // SessionHub takes care of all server-client messaging and game state updates.
+  private final HistoryStore historyStore = new HistoryStore();
+  private final SessionHub session = new SessionHub(historyStore);
 
   private static final AtomicInteger clientCounter = new AtomicInteger(0);
   private int genClientId() { return clientCounter.incrementAndGet(); }

--- a/src/test/java/com/reversi/common/MessageTest.java
+++ b/src/test/java/com/reversi/common/MessageTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import com.reversi.common.GameRecord;
 import org.junit.jupiter.api.Test;
 
 public class MessageTest {
@@ -186,5 +187,28 @@ public class MessageTest {
     Message.GameOver gameoverDeserialized =
         (Message.GameOver)deserialized.getMessage();
     assertTrue(reason.equals(gameoverDeserialized.getReason()));
+  }
+
+  @Test
+  void testSerializeDeserializeHistoryRequest() {
+    var msg = new Message(new Message.HistoryRequest());
+    String json = assertDoesNotThrow(() -> serialize(msg));
+    assertNotNull(json);
+    Message deserialized = assertDoesNotThrow(() -> deserialize(json));
+    assertEquals(Message.Type.HistoryRequest, deserialized.getType());
+  }
+
+  @Test
+  void testSerializeDeserializeHistoryData() {
+    java.util.List<GameRecord> list = new java.util.ArrayList<>();
+    list.add(new GameRecord('B', 10, 5, 1L));
+    var msg = new Message(new Message.HistoryData(list));
+    String json = assertDoesNotThrow(() -> serialize(msg));
+    assertNotNull(json);
+    Message deserialized = assertDoesNotThrow(() -> deserialize(json));
+    assertEquals(Message.Type.HistoryData, deserialized.getType());
+    Message.HistoryData data = (Message.HistoryData)deserialized.getMessage();
+    assertEquals(1, data.getRecords().size());
+    assertEquals('B', data.getRecords().get(0).getWinner());
   }
 }


### PR DESCRIPTION
## Summary
- track finished games in a `game_history.json` file
- load saved history at server startup
- allow clients to request history via new message type
- store results from timeouts or normal game completion
- show history in lobby view
- extend message tests with history serialization cases

## Testing
- `mvn test` *(fails: Could not download JUnit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fea0daaf88324b8b38ffa3227db4b